### PR TITLE
Add 'Add Ingredient' button to shopping list

### DIFF
--- a/src/app/(main)/shopping-list/page.tsx
+++ b/src/app/(main)/shopping-list/page.tsx
@@ -3,15 +3,20 @@
 import { useState } from "react";
 import { ShoppingListView } from "@/components/shopping-list/shopping-list-view";
 import { AddRecipeToList } from "@/components/shopping-list/add-recipe-to-list";
+import { AddIngredientToList } from "@/components/shopping-list/add-ingredient-to-list";
 
 export default function ShoppingListPage() {
   const [refreshKey, setRefreshKey] = useState(0);
+  const refresh = () => setRefreshKey((k) => k + 1);
 
   return (
     <div>
-      <div className="flex items-center justify-between">
+      <div className="flex items-center justify-between gap-2">
         <h1 className="text-2xl font-bold">Shopping List</h1>
-        <AddRecipeToList onAdded={() => setRefreshKey((k) => k + 1)} />
+        <div className="flex gap-2">
+          <AddIngredientToList onAdded={refresh} />
+          <AddRecipeToList onAdded={refresh} />
+        </div>
       </div>
       <div className="mt-4">
         <ShoppingListView key={refreshKey} />

--- a/src/components/shopping-list/add-ingredient-to-list.tsx
+++ b/src/components/shopping-list/add-ingredient-to-list.tsx
@@ -1,0 +1,142 @@
+"use client";
+
+import { useState } from "react";
+import { toast } from "sonner";
+import { Plus } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import { IngredientCombobox } from "@/components/recipes/ingredient-combobox";
+
+interface AddIngredientToListProps {
+  onAdded: () => void;
+}
+
+const EMPTY_INGREDIENT = { ingredientId: "", ingredientName: "" };
+
+export function AddIngredientToList({ onAdded }: AddIngredientToListProps) {
+  const [open, setOpen] = useState(false);
+  const [ingredient, setIngredient] = useState(EMPTY_INGREDIENT);
+  const [quantity, setQuantity] = useState("");
+  const [unit, setUnit] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+
+  function reset() {
+    setIngredient(EMPTY_INGREDIENT);
+    setQuantity("");
+    setUnit("");
+  }
+
+  function handleOpenChange(next: boolean) {
+    setOpen(next);
+    if (!next) reset();
+  }
+
+  async function handleSubmit() {
+    if (!ingredient.ingredientId) return;
+
+    const parsedQty = quantity.trim() ? parseFloat(quantity) : null;
+    if (parsedQty != null && Number.isNaN(parsedQty)) {
+      toast.error("Quantity must be a number");
+      return;
+    }
+
+    setSubmitting(true);
+    try {
+      const res = await fetch("/api/shopping-list", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          ingredients: [
+            {
+              ingredientId: ingredient.ingredientId,
+              quantity: parsedQty,
+              unit: unit.trim() || null,
+            },
+          ],
+        }),
+      });
+      if (!res.ok) throw new Error();
+      toast.success(`Added ${ingredient.ingredientName} to shopping list`);
+      handleOpenChange(false);
+      onAdded();
+    } catch {
+      toast.error("Failed to add ingredient");
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogTrigger>
+        <Button size="sm" variant="outline">
+          <Plus className="mr-1 h-4 w-4" />
+          Add Ingredient
+        </Button>
+      </DialogTrigger>
+      <DialogContent className="max-h-[80vh] overflow-y-auto sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>Add Ingredient</DialogTitle>
+        </DialogHeader>
+
+        <div className="space-y-4">
+          <div className="space-y-2">
+            <Label>Ingredient</Label>
+            <IngredientCombobox
+              value={ingredient}
+              onChange={setIngredient}
+            />
+          </div>
+          <div className="flex gap-2">
+            <div className="flex-1 space-y-2">
+              <Label htmlFor="add-ing-qty">Quantity</Label>
+              <Input
+                id="add-ing-qty"
+                type="number"
+                step="any"
+                inputMode="decimal"
+                value={quantity}
+                onChange={(e) => setQuantity(e.target.value)}
+                placeholder="Qty"
+              />
+            </div>
+            <div className="flex-1 space-y-2">
+              <Label htmlFor="add-ing-unit">Unit</Label>
+              <Input
+                id="add-ing-unit"
+                value={unit}
+                onChange={(e) => setUnit(e.target.value)}
+                placeholder="e.g. cup"
+              />
+            </div>
+          </div>
+        </div>
+
+        <DialogFooter>
+          <Button
+            variant="outline"
+            onClick={() => handleOpenChange(false)}
+            disabled={submitting}
+          >
+            Cancel
+          </Button>
+          <Button
+            onClick={handleSubmit}
+            disabled={!ingredient.ingredientId || submitting}
+          >
+            {submitting ? "Adding..." : "Add"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/lib/validators/shopping-list.ts
+++ b/src/lib/validators/shopping-list.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 
 export const addRecipeIngredientsSchema = z.object({
-  recipeId: z.string(),
+  recipeId: z.string().optional(),
   ingredients: z
     .array(
       z.object({


### PR DESCRIPTION
## Summary
- New **Add Ingredient** button next to **Add Recipe** on the shopping list page, opening a modal to add a single ingredient with optional quantity and unit.
- Reuses `IngredientCombobox` from the recipe form, so users can search existing ingredients or create a new one inline (same flow as the recipe editor).
- Posts to the existing `/api/shopping-list` endpoint as a single-item ingredients array — aggregation/dedup behavior matches recipe-based adds (matching `ingredientId:unit` rows are summed).
- Made `recipeId` optional in `addRecipeIngredientsSchema`; the route never read it.

## Test plan
- [ ] Open `/shopping-list` and confirm both buttons render side-by-side
- [ ] Click **Add Ingredient**, search and pick an existing ingredient, enter qty + unit, submit → item appears in list under correct category
- [ ] Add the same ingredient + unit again with a quantity → quantity aggregates on the existing row
- [ ] Add an ingredient with no qty/unit → row is created with null qty/unit
- [ ] In the combobox, choose **Create new ingredient**, fill out the dialog, then return to the add flow and submit → new ingredient is created and added
- [ ] Cancel button and clicking outside both reset form state on next open

🤖 Generated with [Claude Code](https://claude.com/claude-code)