### PR TITLE
Edit shopping list items via bottom sheet

### DIFF
--- a/src/app/api/shopping-list/items/[id]/route.ts
+++ b/src/app/api/shopping-list/items/[id]/route.ts
@@ -1,0 +1,77 @@
+import { NextRequest, NextResponse } from "next/server";
+import { auth } from "@/lib/auth";
+import { prisma } from "@/lib/prisma";
+import { updateItemSchema } from "@/lib/validators/shopping-list";
+
+async function requireOwnedItem(itemId: string, userId: string) {
+  const item = await prisma.shoppingListItem.findUnique({
+    where: { id: itemId },
+    select: { id: true, shoppingList: { select: { userId: true } } },
+  });
+  if (!item) return { error: "Not found" as const, status: 404 as const };
+  if (item.shoppingList.userId !== userId) {
+    return { error: "Forbidden" as const, status: 403 as const };
+  }
+  return { item };
+}
+
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const session = await auth();
+  if (!session?.user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { id } = await params;
+
+  const body = await request.json();
+  const parsed = updateItemSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: "Validation failed", issues: parsed.error.issues },
+      { status: 400 }
+    );
+  }
+
+  const ownership = await requireOwnedItem(id, session.user.id);
+  if ("error" in ownership) {
+    return NextResponse.json({ error: ownership.error }, { status: ownership.status });
+  }
+
+  const data: { quantity?: number | null; unit?: string | null } = {};
+  if (parsed.data.quantity !== undefined) data.quantity = parsed.data.quantity;
+  if (parsed.data.unit !== undefined) {
+    data.unit = parsed.data.unit ? parsed.data.unit.trim() || null : null;
+  }
+
+  const updated = await prisma.shoppingListItem.update({
+    where: { id },
+    data,
+    include: { ingredient: true },
+  });
+
+  return NextResponse.json(updated);
+}
+
+export async function DELETE(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const session = await auth();
+  if (!session?.user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { id } = await params;
+
+  const ownership = await requireOwnedItem(id, session.user.id);
+  if ("error" in ownership) {
+    return NextResponse.json({ error: ownership.error }, { status: ownership.status });
+  }
+
+  await prisma.shoppingListItem.delete({ where: { id } });
+
+  return NextResponse.json({ success: true });
+}

--- a/src/components/shopping-list/edit-shopping-item-sheet.tsx
+++ b/src/components/shopping-list/edit-shopping-item-sheet.tsx
@@ -1,0 +1,196 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { toast } from "sonner";
+import { Minus, Plus, Trash2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Sheet,
+  SheetContent,
+  SheetFooter,
+  SheetHeader,
+  SheetTitle,
+} from "@/components/ui/sheet";
+import { toTitleCase } from "@/lib/utils";
+
+interface EditShoppingItemSheetProps {
+  item: {
+    id: string;
+    quantity: number | null;
+    unit: string | null;
+    ingredient: { name: string };
+  } | null;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onUpdated: (
+    itemId: string,
+    patch: { quantity: number | null; unit: string | null }
+  ) => void;
+  onRemoved: (itemId: string) => void;
+}
+
+export function EditShoppingItemSheet({
+  item,
+  open,
+  onOpenChange,
+  onUpdated,
+  onRemoved,
+}: EditShoppingItemSheetProps) {
+  const [quantity, setQuantity] = useState("");
+  const [unit, setUnit] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+
+  useEffect(() => {
+    if (item) {
+      setQuantity(item.quantity != null ? String(item.quantity) : "");
+      setUnit(item.unit ?? "");
+    }
+  }, [item]);
+
+  function adjustQuantity(delta: number) {
+    const current = quantity.trim() === "" ? 0 : parseFloat(quantity);
+    if (Number.isNaN(current)) return;
+    const next = Math.max(0, current + delta);
+    // Trim trailing .0 for integers
+    setQuantity(Number.isInteger(next) ? String(next) : String(next));
+  }
+
+  async function handleSave() {
+    if (!item) return;
+
+    const trimmedQty = quantity.trim();
+    let parsedQty: number | null = null;
+    if (trimmedQty !== "") {
+      parsedQty = parseFloat(trimmedQty);
+      if (Number.isNaN(parsedQty) || parsedQty < 0) {
+        toast.error("Quantity must be a non-negative number");
+        return;
+      }
+    }
+    const trimmedUnit = unit.trim() || null;
+
+    setSubmitting(true);
+    try {
+      const res = await fetch(`/api/shopping-list/items/${item.id}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ quantity: parsedQty, unit: trimmedUnit }),
+      });
+      if (!res.ok) throw new Error();
+      onUpdated(item.id, { quantity: parsedQty, unit: trimmedUnit });
+      onOpenChange(false);
+    } catch {
+      toast.error("Failed to update item");
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  async function handleRemove() {
+    if (!item) return;
+
+    setSubmitting(true);
+    try {
+      const res = await fetch(`/api/shopping-list/items/${item.id}`, {
+        method: "DELETE",
+      });
+      if (!res.ok) throw new Error();
+      onRemoved(item.id);
+      onOpenChange(false);
+      toast.success("Item removed");
+    } catch {
+      toast.error("Failed to remove item");
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      <SheetContent side="bottom" className="rounded-t-xl">
+        <SheetHeader>
+          <SheetTitle>
+            {item ? toTitleCase(item.ingredient.name) : "Edit item"}
+          </SheetTitle>
+        </SheetHeader>
+
+        <div className="space-y-4 px-4 pb-2">
+          <div className="space-y-2">
+            <Label htmlFor="edit-item-qty">Quantity</Label>
+            <div className="flex items-center gap-2">
+              <Button
+                type="button"
+                variant="outline"
+                size="icon"
+                onClick={() => adjustQuantity(-1)}
+                disabled={submitting}
+                aria-label="Decrease quantity"
+              >
+                <Minus className="h-4 w-4" />
+              </Button>
+              <Input
+                id="edit-item-qty"
+                type="number"
+                step="any"
+                min="0"
+                inputMode="decimal"
+                value={quantity}
+                onChange={(e) => setQuantity(e.target.value)}
+                placeholder="—"
+                className="text-center"
+              />
+              <Button
+                type="button"
+                variant="outline"
+                size="icon"
+                onClick={() => adjustQuantity(1)}
+                disabled={submitting}
+                aria-label="Increase quantity"
+              >
+                <Plus className="h-4 w-4" />
+              </Button>
+            </div>
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="edit-item-unit">Unit</Label>
+            <Input
+              id="edit-item-unit"
+              value={unit}
+              onChange={(e) => setUnit(e.target.value)}
+              placeholder="e.g. cup"
+            />
+          </div>
+        </div>
+
+        <SheetFooter className="flex-row justify-between sm:flex-row">
+          <Button
+            type="button"
+            variant="ghost"
+            onClick={handleRemove}
+            disabled={submitting}
+            className="text-destructive hover:text-destructive"
+          >
+            <Trash2 className="mr-1 h-4 w-4" />
+            Remove
+          </Button>
+          <div className="flex gap-2">
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => onOpenChange(false)}
+              disabled={submitting}
+            >
+              Cancel
+            </Button>
+            <Button type="button" onClick={handleSave} disabled={submitting}>
+              {submitting ? "Saving..." : "Save"}
+            </Button>
+          </div>
+        </SheetFooter>
+      </SheetContent>
+    </Sheet>
+  );
+}

--- a/src/components/shopping-list/shopping-list-view.tsx
+++ b/src/components/shopping-list/shopping-list-view.tsx
@@ -28,6 +28,7 @@ import { CSS } from "@dnd-kit/utilities";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Separator } from "@/components/ui/separator";
+import { EditShoppingItemSheet } from "@/components/shopping-list/edit-shopping-item-sheet";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -59,6 +60,7 @@ interface ShoppingListData {
 export function ShoppingListView() {
   const [list, setList] = useState<ShoppingListData | null>(null);
   const [loading, setLoading] = useState(true);
+  const [editingItemId, setEditingItemId] = useState<string | null>(null);
 
   const sensors = useSensors(
     useSensor(PointerSensor, { activationConstraint: { distance: 5 } }),
@@ -103,6 +105,28 @@ export function ShoppingListView() {
     } catch {
       toast.error("Failed to update item");
     }
+  }
+
+  function applyItemPatch(
+    itemId: string,
+    patch: { quantity: number | null; unit: string | null }
+  ) {
+    setList((prev) => {
+      if (!prev) return prev;
+      return {
+        ...prev,
+        items: prev.items.map((item) =>
+          item.id === itemId ? { ...item, ...patch } : item
+        ),
+      };
+    });
+  }
+
+  function removeItemFromState(itemId: string) {
+    setList((prev) => {
+      if (!prev) return prev;
+      return { ...prev, items: prev.items.filter((i) => i.id !== itemId) };
+    });
   }
 
   async function handleExport() {
@@ -246,6 +270,7 @@ export function ShoppingListView() {
                     key={item.id}
                     item={item}
                     onToggle={toggleItem}
+                    onEdit={setEditingItemId}
                   />
                 ))}
               </div>
@@ -254,6 +279,16 @@ export function ShoppingListView() {
           <Separator className="mt-3" />
         </div>
       ))}
+
+      <EditShoppingItemSheet
+        item={list.items.find((i) => i.id === editingItemId) ?? null}
+        open={editingItemId !== null}
+        onOpenChange={(next) => {
+          if (!next) setEditingItemId(null);
+        }}
+        onUpdated={applyItemPatch}
+        onRemoved={removeItemFromState}
+      />
     </div>
   );
 }
@@ -261,9 +296,14 @@ export function ShoppingListView() {
 interface SortableShoppingItemProps {
   item: ShoppingItem;
   onToggle: (itemId: string, checked: boolean) => void;
+  onEdit: (itemId: string) => void;
 }
 
-function SortableShoppingItem({ item, onToggle }: SortableShoppingItemProps) {
+function SortableShoppingItem({
+  item,
+  onToggle,
+  onEdit,
+}: SortableShoppingItemProps) {
   const {
     attributes,
     listeners,
@@ -282,7 +322,7 @@ function SortableShoppingItem({ item, onToggle }: SortableShoppingItemProps) {
     <div
       ref={setNodeRef}
       style={style}
-      className={`flex items-center gap-2 rounded-md px-2 py-2.5 hover:bg-accent ${
+      className={`flex items-center gap-2 rounded-md px-2 hover:bg-accent ${
         isDragging ? "z-10 bg-background shadow-lg" : ""
       }`}
     >
@@ -295,11 +335,19 @@ function SortableShoppingItem({ item, onToggle }: SortableShoppingItemProps) {
       >
         <GripVertical className="h-5 w-5" />
       </button>
-      <label className="flex flex-1 items-center gap-3 cursor-pointer">
+      <div className="py-2.5">
         <Checkbox
           checked={item.checked}
           onCheckedChange={(checked) => onToggle(item.id, checked === true)}
+          aria-label={`Mark ${item.ingredient.name} as ${item.checked ? "not done" : "done"}`}
         />
+      </div>
+      <button
+        type="button"
+        onClick={() => onEdit(item.id)}
+        className="flex-1 cursor-pointer py-2.5 pl-3 text-left"
+        aria-label={`Edit ${item.ingredient.name}`}
+      >
         <span
           className={
             item.checked
@@ -310,9 +358,9 @@ function SortableShoppingItem({ item, onToggle }: SortableShoppingItemProps) {
           {toTitleCase(item.ingredient.name)}
           {" "}
           {item.quantity != null && <strong>{item.quantity}</strong>}
-          {item.unit && ` ${item.unit}`}          
+          {item.unit && ` ${item.unit}`}
         </span>
-      </label>
+      </button>
     </div>
   );
 }

--- a/src/lib/validators/shopping-list.ts
+++ b/src/lib/validators/shopping-list.ts
@@ -18,6 +18,15 @@ export const checkItemSchema = z.object({
   checked: z.boolean(),
 });
 
+export const updateItemSchema = z
+  .object({
+    quantity: z.number().nullable().optional(),
+    unit: z.string().nullable().optional(),
+  })
+  .refine((d) => d.quantity !== undefined || d.unit !== undefined, {
+    message: "At least one field must be provided",
+  });
+
 export const reorderItemsSchema = z.object({
   items: z
     .array(


### PR DESCRIPTION
## Summary
- Tap an item's text on the shopping list to open a bottom sheet with quantity stepper (−/+), unit input, and a destructive Remove action.
- Checkbox remains its own tap target on the left, so checking items off works exactly as before. Drag handle behavior is unchanged.
- New `PATCH`/`DELETE /api/shopping-list/items/[id]` route handles per-item updates and removal, with ownership verification on both.

## Design notes
- Chose tap-to-edit over hover-only-on-desktop and long-press-on-mobile: discoverable, identical across platforms, and gives the bottom sheet enough room for a tap-friendly quantity stepper.
- Tradeoff: tapping the item text used to toggle the checkbox (via `<label>` wrap). It now opens the edit sheet. The checkbox itself still toggles when tapped directly.

## Test plan
- [ ] Tap an item → bottom sheet opens with current quantity & unit prefilled.
- [ ] − / + adjust quantity by 1; minus floors at 0; manual decimal input is preserved.
- [ ] Save persists the new quantity/unit and updates the row inline.
- [ ] Empty quantity saves as null (no quantity displayed).
- [ ] Remove deletes the item from the list and shows a toast.
- [ ] Cancel discards changes.
- [ ] Checking/unchecking an item still works (independent of the sheet).
- [ ] Drag-to-reorder still works (no accidental sheet opening when starting a drag).
- [ ] Try to PATCH/DELETE another user's item → 403.

🤖 Generated with [Claude Code](https://claude.com/claude-code)