### PR TITLE
Scale shopping-list ingredients by servings

### DIFF
--- a/src/app/api/recipes/[id]/ingredients/route.ts
+++ b/src/app/api/recipes/[id]/ingredients/route.ts
@@ -13,11 +13,23 @@ export async function GET(
 
   const { id } = await params;
 
-  const ingredients = await prisma.recipeIngredient.findMany({
-    where: { recipeId: id },
-    include: { ingredient: true },
-    orderBy: { orderIndex: "asc" },
+  const recipe = await prisma.recipe.findUnique({
+    where: { id },
+    select: {
+      servings: true,
+      ingredients: {
+        include: { ingredient: true },
+        orderBy: { orderIndex: "asc" },
+      },
+    },
   });
 
-  return NextResponse.json(ingredients);
+  if (!recipe) {
+    return NextResponse.json({ error: "Recipe not found" }, { status: 404 });
+  }
+
+  return NextResponse.json({
+    servings: recipe.servings,
+    ingredients: recipe.ingredients,
+  });
 }

--- a/src/components/recipes/servings-adjuster.tsx
+++ b/src/components/recipes/servings-adjuster.tsx
@@ -3,7 +3,7 @@
 import { useState } from "react";
 import { Minus, Plus } from "lucide-react";
 import { Button } from "@/components/ui/button";
-import { toTitleCase } from "@/lib/utils";
+import { formatQuantity, toTitleCase } from "@/lib/utils";
 
 interface Ingredient {
   id: string;
@@ -16,25 +16,6 @@ interface Ingredient {
 interface ServingsAdjusterProps {
   baseServings: number;
   ingredients: Ingredient[];
-}
-
-function formatQuantity(q: number): string {
-  if (q === Math.floor(q)) return q.toString();
-  // Common fractions
-  const frac = q - Math.floor(q);
-  const whole = Math.floor(q);
-  const fractions: Record<string, string> = {
-    "0.25": "\u00BC",
-    "0.33": "\u2153",
-    "0.5": "\u00BD",
-    "0.67": "\u2154",
-    "0.75": "\u00BE",
-  };
-  const key = frac.toFixed(2);
-  if (fractions[key]) {
-    return whole > 0 ? `${whole}${fractions[key]}` : fractions[key];
-  }
-  return q.toFixed(1);
 }
 
 export function ServingsAdjuster({ baseServings, ingredients }: ServingsAdjusterProps) {

--- a/src/components/shopping-list/ingredient-selector.tsx
+++ b/src/components/shopping-list/ingredient-selector.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect } from "react";
 import { toast } from "sonner";
-import { Loader2 } from "lucide-react";
+import { Loader2, Minus, Plus } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Separator } from "@/components/ui/separator";
@@ -12,7 +12,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
-import { toTitleCase } from "@/lib/utils";
+import { formatQuantity, toTitleCase } from "@/lib/utils";
 
 interface RecipeIngredient {
   id: string;
@@ -21,6 +21,11 @@ interface RecipeIngredient {
   unit: string | null;
   preparation: string | null;
   ingredient: { id: string; name: string; category: string };
+}
+
+interface IngredientsResponse {
+  servings: number;
+  ingredients: RecipeIngredient[];
 }
 
 interface IngredientSelectorContentProps {
@@ -40,13 +45,17 @@ export function IngredientSelectorContent({
   const [selected, setSelected] = useState<Set<string>>(new Set());
   const [loading, setLoading] = useState(true);
   const [submitting, setSubmitting] = useState(false);
+  const [baseServings, setBaseServings] = useState<number | null>(null);
+  const [servings, setServings] = useState<number | null>(null);
 
   useEffect(() => {
     fetch(`/api/recipes/${recipeId}/ingredients`)
       .then((r) => r.json())
-      .then((data: RecipeIngredient[]) => {
-        setIngredients(data);
-        setSelected(new Set(data.map((i) => i.id)));
+      .then((data: IngredientsResponse) => {
+        setIngredients(data.ingredients);
+        setSelected(new Set(data.ingredients.map((i) => i.id)));
+        setBaseServings(data.servings);
+        setServings(data.servings);
       })
       .catch(() => toast.error("Failed to load ingredients"))
       .finally(() => setLoading(false));
@@ -74,7 +83,7 @@ export function IngredientSelectorContent({
       .filter((i) => selected.has(i.id))
       .map((i) => ({
         ingredientId: i.ingredientId,
-        quantity: i.quantity,
+        quantity: i.quantity != null ? i.quantity * scale : null,
         unit: i.unit,
       }));
 
@@ -119,6 +128,8 @@ export function IngredientSelectorContent({
   }
 
   const allSelected = selected.size === ingredients.length;
+  const scale =
+    baseServings && servings && baseServings > 0 ? servings / baseServings : 1;
 
   return (
     <div className="space-y-4">
@@ -126,6 +137,38 @@ export function IngredientSelectorContent({
         Select ingredients from <strong>{recipeTitle}</strong> to add to your
         shopping list.
       </p>
+
+      {baseServings != null && servings != null && (
+        <div className="flex flex-wrap items-center gap-3">
+          <span className="text-sm font-medium">Servings:</span>
+          <div className="flex items-center gap-2">
+            <Button
+              variant="outline"
+              size="icon"
+              onClick={() => setServings(Math.max(1, servings - 1))}
+              disabled={servings <= 1}
+            >
+              <Minus className="h-4 w-4" />
+            </Button>
+            <span className="w-8 text-center font-semibold">{servings}</span>
+            <Button
+              variant="outline"
+              size="icon"
+              onClick={() => setServings(servings + 1)}
+            >
+              <Plus className="h-4 w-4" />
+            </Button>
+          </div>
+          {servings !== baseServings && (
+            <button
+              className="text-xs text-primary hover:underline"
+              onClick={() => setServings(baseServings)}
+            >
+              Reset
+            </button>
+          )}
+        </div>
+      )}
 
       <label className="flex items-center gap-3 rounded-md px-3 py-3 md:py-2 hover:bg-accent cursor-pointer">
         <Checkbox checked={allSelected} onCheckedChange={toggleAll} />
@@ -137,27 +180,30 @@ export function IngredientSelectorContent({
       <Separator />
 
       <div className="max-h-[40vh] space-y-1 overflow-y-auto">
-        {ingredients.map((ing) => (
-          <label
-            key={ing.id}
-            className="flex items-center gap-3 rounded-md px-3 py-3 md:py-1.5 hover:bg-accent cursor-pointer"
-          >
-            <Checkbox
-              checked={selected.has(ing.id)}
-              onCheckedChange={() => toggleOne(ing.id)}
-            />
-            <span className="text-base md:text-sm">
-              {ing.quantity != null && <strong>{ing.quantity}</strong>}
-              {ing.unit && ` ${ing.unit}`}{" "}
-              {toTitleCase(ing.ingredient.name)}
-              {ing.preparation && (
-                <span className="text-muted-foreground">
-                  , {ing.preparation}
-                </span>
-              )}
-            </span>
-          </label>
-        ))}
+        {ingredients.map((ing) => {
+          const scaledQty = ing.quantity != null ? ing.quantity * scale : null;
+          return (
+            <label
+              key={ing.id}
+              className="flex items-center gap-3 rounded-md px-3 py-3 md:py-1.5 hover:bg-accent cursor-pointer"
+            >
+              <Checkbox
+                checked={selected.has(ing.id)}
+                onCheckedChange={() => toggleOne(ing.id)}
+              />
+              <span className="text-base md:text-sm">
+                {scaledQty != null && <strong>{formatQuantity(scaledQty)}</strong>}
+                {ing.unit && ` ${ing.unit}`}{" "}
+                {toTitleCase(ing.ingredient.name)}
+                {ing.preparation && (
+                  <span className="text-muted-foreground">
+                    , {ing.preparation}
+                  </span>
+                )}
+              </span>
+            </label>
+          );
+        })}
       </div>
 
       <div className="flex gap-2">

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -11,3 +11,21 @@ export function toTitleCase(str: string) {
     .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
     .join(" ");
 }
+
+export function formatQuantity(q: number): string {
+  if (q === Math.floor(q)) return q.toString();
+  const frac = q - Math.floor(q);
+  const whole = Math.floor(q);
+  const fractions: Record<string, string> = {
+    "0.25": "¼",
+    "0.33": "⅓",
+    "0.5": "½",
+    "0.67": "⅔",
+    "0.75": "¾",
+  };
+  const key = frac.toFixed(2);
+  if (fractions[key]) {
+    return whole > 0 ? `${whole}${fractions[key]}` : fractions[key];
+  }
+  return q.toFixed(1);
+}


### PR DESCRIPTION
## Summary
- Add a "Servings: − N +" adjuster to the recipe ingredient selector on the shopping list page
- Scale displayed and submitted quantities by `newServings / recipeServings` (ingredients without quantities pass through unchanged)
- Extract `formatQuantity` into `lib/utils` so the selector and the recipe-detail `ServingsAdjuster` share one fraction formatter
- `/api/recipes/[id]/ingredients` now returns `{ servings, ingredients }` (single consumer updated)

## Test plan
- [ ] On the shopping list page, click **Add Recipe**, pick a recipe → modal shows Servings control defaulted to the recipe's servings
- [ ] Increment/decrement servings → ingredient quantities rescale live; "Reset" appears when changed
- [ ] Decrement is disabled at 1; ingredients without a quantity render unchanged
- [ ] Add at 2× / 3× → shopping list shows correctly multiplied quantities
- [ ] Recipe detail page servings adjuster still works (regression check on shared `formatQuantity`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)